### PR TITLE
Fix whitespace in AboutComponent title test

### DIFF
--- a/src/app/components/pages/about/abount.component.spec.ts
+++ b/src/app/components/pages/about/abount.component.spec.ts
@@ -22,6 +22,6 @@ describe('AbountComponent', () => {
       compiled.querySelector(
         'div.container div.text-center h3.section-subheading.text-muted'
       )?.textContent
-    ).toBe(' Saiba mais sobre minha carreira. ');
+    ).toBe('Saiba mais sobre minha carreira.');
   });
 });


### PR DESCRIPTION
Remove extra whitespace in the expected title string for the AboutComponent test.